### PR TITLE
fix for Unable to access 'path.scripts'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,5 +23,6 @@ elastic:
     - ./esdata:/data
     - ./elastic/plugins:/plugins
     - ./elastic/conf:/usr/share/elasticsearch/config
+    - ./elastic/scripts:/usr/share/elasticsearch/config/scripts
   environment:
     - neo4j="http://neo4j"


### PR DESCRIPTION
This Pull Request will fix the following error
```
elastic_container | Exception in thread "main" java.lang.IllegalStateException: Unable to access 'path.scripts' (/usr/share/elasticsearch/config/scripts)
elastic_container | Likely root cause: java.nio.file.AccessDeniedException: /usr/share/elasticsearch/config/scripts
elastic_container | 	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:84)
```
Thanks,
Aashish